### PR TITLE
Restricting the access to `package` - mind your architecture

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,14 @@
             <version>2.3.1</version>
         </dependency>
 
+		<!--AchUnit lib-->
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit4</artifactId>
+			<version>0.9.2</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/io/axoniq/demo/giftcard/api/package-info.java
+++ b/src/main/java/io/axoniq/demo/giftcard/api/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API: Commands, Event and Queries
+ */
+package io.axoniq.demo.giftcard.api;

--- a/src/main/java/io/axoniq/demo/giftcard/command/GcCommandConfiguration.java
+++ b/src/main/java/io/axoniq/demo/giftcard/command/GcCommandConfiguration.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Profile("command")
-public class GcCommandConfiguration {
+class GcCommandConfiguration {
 
 	@Bean
 	public Repository<GiftCard> giftCardRepository(EventStore eventStore, Cache cache) {

--- a/src/main/java/io/axoniq/demo/giftcard/command/GcCommandConfiguration.java
+++ b/src/main/java/io/axoniq/demo/giftcard/command/GcCommandConfiguration.java
@@ -14,14 +14,14 @@ import org.springframework.stereotype.Component;
 class GcCommandConfiguration {
 
 	@Bean
-	public Repository<GiftCard> giftCardRepository(EventStore eventStore, Cache cache) {
+	Repository<GiftCard> giftCardRepository(EventStore eventStore, Cache cache) {
 		return EventSourcingRepository.builder(GiftCard.class)
 				.cache(cache).eventStore(eventStore)
 				.build();
 	}
 
 	@Bean
-    public Cache cache() {
+	Cache cache() {
 	    return new WeakReferenceCache();
 	}
 }

--- a/src/main/java/io/axoniq/demo/giftcard/command/GiftCard.java
+++ b/src/main/java/io/axoniq/demo/giftcard/command/GiftCard.java
@@ -15,7 +15,7 @@ import static org.axonframework.modelling.command.AggregateLifecycle.apply;
 
 @Aggregate
 @Profile("command")
-public class GiftCard {
+class GiftCard {
 
     private final static Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/src/main/java/io/axoniq/demo/giftcard/command/GiftCard.java
+++ b/src/main/java/io/axoniq/demo/giftcard/command/GiftCard.java
@@ -28,14 +28,14 @@ class GiftCard {
     }
 
     @CommandHandler
-    public GiftCard(IssueCmd cmd) {
+    GiftCard(IssueCmd cmd) {
         log.debug("handling {}", cmd);
         if(cmd.getAmount() <= 0) throw new IllegalArgumentException("amount <= 0");
         apply(new IssuedEvt(cmd.getId(), cmd.getAmount()));
     }
 
     @CommandHandler
-    public void handle(RedeemCmd cmd) {
+    void handle(RedeemCmd cmd) {
         log.debug("handling {}", cmd);
         if(cmd.getAmount() <= 0) throw new IllegalArgumentException("amount <= 0");
         if(cmd.getAmount() > remainingValue) throw new IllegalStateException("amount > remaining value");
@@ -43,13 +43,13 @@ class GiftCard {
     }
 
     @CommandHandler
-    public void handle(CancelCmd cmd) {
+    void handle(CancelCmd cmd) {
         log.debug("handling {}", cmd);
         apply(new CancelEvt(id));
     }
 
     @EventSourcingHandler
-    public void on(IssuedEvt evt) {
+    void on(IssuedEvt evt) {
         log.debug("applying {}", evt);
         id = evt.getId();
         remainingValue = evt.getAmount();
@@ -57,14 +57,14 @@ class GiftCard {
     }
 
     @EventSourcingHandler
-    public void on(RedeemedEvt evt) {
+    void on(RedeemedEvt evt) {
         log.debug("applying {}", evt);
         remainingValue -= evt.getAmount();
         log.debug("new remaining value: {}", remainingValue);
     }
 
     @EventSourcingHandler
-    public void on(CancelEvt evt) {
+    void on(CancelEvt evt) {
         log.debug("applying {}", evt);
         remainingValue = 0;
         log.debug("new remaining value: {}", remainingValue);

--- a/src/main/java/io/axoniq/demo/giftcard/command/package-info.java
+++ b/src/main/java/io/axoniq/demo/giftcard/command/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Command model: Aggregates, Sagas, External command handlers
+ */
+package io.axoniq.demo.giftcard.command;

--- a/src/main/java/io/axoniq/demo/giftcard/gui/BulkIssuer.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/BulkIssuer.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-public class BulkIssuer {
+class BulkIssuer {
 
     private final static Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/src/main/java/io/axoniq/demo/giftcard/gui/BulkIssuer.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/BulkIssuer.java
@@ -1,7 +1,6 @@
 package io.axoniq.demo.giftcard.gui;
 
 import io.axoniq.demo.giftcard.api.IssueCmd;
-import com.vaadin.ui.UI;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +18,7 @@ class BulkIssuer {
     private final AtomicInteger error = new AtomicInteger();
     private final AtomicInteger remaining = new AtomicInteger();
 
-    public BulkIssuer(CommandGateway commandGateway, int number, int amount, Consumer<BulkIssuer> callback) {
+    BulkIssuer(CommandGateway commandGateway, int number, int amount, Consumer<BulkIssuer> callback) {
         remaining.set(number);
         new Thread(() -> {
             for(int i = 0; i < number; i++) {
@@ -50,15 +49,15 @@ class BulkIssuer {
         }).start();
     }
 
-    public AtomicInteger getSuccess() {
+    AtomicInteger getSuccess() {
         return success;
     }
 
-    public AtomicInteger getError() {
+    AtomicInteger getError() {
         return error;
     }
 
-    public AtomicInteger getRemaining() {
+    AtomicInteger getRemaining() {
         return remaining;
     }
 

--- a/src/main/java/io/axoniq/demo/giftcard/gui/CardSummaryDataProvider.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/CardSummaryDataProvider.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
 
 @XSlf4j
 @RequiredArgsConstructor
-public class CardSummaryDataProvider extends AbstractBackEndDataProvider<CardSummary, Void> {
+class CardSummaryDataProvider extends AbstractBackEndDataProvider<CardSummary, Void> {
 
     private static final ExecutorService executorService = Executors.newCachedThreadPool();
 

--- a/src/main/java/io/axoniq/demo/giftcard/gui/GcGuiConfiguration.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/GcGuiConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 class GcGuiConfiguration {
 
 	@EventListener(ApplicationReadyEvent.class)
-	public void helloHub(ApplicationReadyEvent event) {
+	void helloHub(ApplicationReadyEvent event) {
 		QueryGateway queryGateway = event.getApplicationContext().getBean(QueryGateway.class);
 		queryGateway.query(new CountCardSummariesQuery(),
 				ResponseTypes.instanceOf(CountCardSummariesResponse.class));

--- a/src/main/java/io/axoniq/demo/giftcard/gui/GcGuiConfiguration.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/GcGuiConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Profile("gui")
-public class GcGuiConfiguration {
+class GcGuiConfiguration {
 
 	@EventListener(ApplicationReadyEvent.class)
 	public void helloHub(ApplicationReadyEvent event) {

--- a/src/main/java/io/axoniq/demo/giftcard/gui/GiftcardUI.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/GiftcardUI.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 @SpringUI
 @Push
 @Profile("gui")
-public class GiftcardUI extends UI {
+class GiftcardUI extends UI {
 
     private final static Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -64,7 +64,7 @@ public class GiftcardUI extends UI {
             public void error(com.vaadin.server.ErrorEvent event) {
                 Throwable cause = event.getThrowable();
                 log.error("an error occured", cause);
-                while(cause.getCause() != null) cause = cause.getCause();
+                while (cause.getCause() != null) cause = cause.getCause();
                 Notification.show("Error", cause.getMessage(), Notification.Type.ERROR_MESSAGE);
             }
         });
@@ -72,15 +72,15 @@ public class GiftcardUI extends UI {
         setPollInterval(1000);
         int offset = Page.getCurrent().getWebBrowser().getTimezoneOffset();
         // offset is in milliseconds
-             ZoneOffset instantOffset = ZoneOffset.ofTotalSeconds(offset/1000);
+        ZoneOffset instantOffset = ZoneOffset.ofTotalSeconds(offset / 1000);
         StatusUpdater statusUpdater = new StatusUpdater(statusLabel, instantOffset);
         updaterThread = Executors.newScheduledThreadPool(1).scheduleAtFixedRate(statusUpdater, 1000,
-                                                                     5000, TimeUnit.MILLISECONDS);
+                5000, TimeUnit.MILLISECONDS);
         setPollInterval(1000);
         getSession().getSession().setMaxInactiveInterval(30);
         addDetachListener((DetachListener) detachEvent -> {
-             log.warn("Closing UI");
-             updaterThread.cancel(true);
+            log.warn("Closing UI");
+            updaterThread.cancel(true);
 
         });
 
@@ -115,20 +115,20 @@ public class GiftcardUI extends UI {
         submit.addClickListener(evt -> {
             submit.setEnabled(false);
             new BulkIssuer(commandGateway, Integer.parseInt(number.getValue()), Integer.parseInt(amount.getValue()),
-                bulkIssuer -> {
-                    access(() -> {
-                        if(bulkIssuer.getRemaining().get() == 0) {
-                            submit.setEnabled(true);
-                            panel.setCaption("Bulk issue cards");
-                            Notification.show("Bulk issue card completed", Notification.Type.HUMANIZED_MESSAGE)
-                                    .addCloseListener(e -> cardSummaryDataProvider.refreshAll());
-                        } else {
-                            panel.setCaption(String.format("Progress: %d suc, %d fail, %d rem", bulkIssuer.getSuccess().get(),
-                                    bulkIssuer.getError().get(), bulkIssuer.getRemaining().get()));
-                            cardSummaryDataProvider.refreshAll();
-                        }
+                    bulkIssuer -> {
+                        access(() -> {
+                            if (bulkIssuer.getRemaining().get() == 0) {
+                                submit.setEnabled(true);
+                                panel.setCaption("Bulk issue cards");
+                                Notification.show("Bulk issue card completed", Notification.Type.HUMANIZED_MESSAGE)
+                                        .addCloseListener(e -> cardSummaryDataProvider.refreshAll());
+                            } else {
+                                panel.setCaption(String.format("Progress: %d suc, %d fail, %d rem", bulkIssuer.getSuccess().get(),
+                                        bulkIssuer.getError().get(), bulkIssuer.getRemaining().get()));
+                                cardSummaryDataProvider.refreshAll();
+                            }
+                        });
                     });
-                });
         });
 
         FormLayout form = new FormLayout();
@@ -170,24 +170,25 @@ public class GiftcardUI extends UI {
         return grid;
     }
 
-    public class StatusUpdater implements Runnable {
+    class StatusUpdater implements Runnable {
         private final Label statusLabel;
-         private final ZoneOffset instantOffset;
+        private final ZoneOffset instantOffset;
 
-         public StatusUpdater(Label statusLabel, ZoneOffset instantOffset) {
-             this.statusLabel = statusLabel;
-             this.instantOffset = instantOffset;
-         }
+        public StatusUpdater(Label statusLabel, ZoneOffset instantOffset) {
+            this.statusLabel = statusLabel;
+            this.instantOffset = instantOffset;
+        }
 
-         @Override
-         public void run() {
-             CountCardSummariesQuery query = new CountCardSummariesQuery();
-             queryGateway.query(
-                     query, CountCardSummariesResponse.class).whenComplete((r, exception) -> {
-                 if( exception == null) statusLabel.setValue(Instant.ofEpochMilli(r.getLastEvent()).atOffset(instantOffset).toString());
-             });
+        @Override
+        public void run() {
+            CountCardSummariesQuery query = new CountCardSummariesQuery();
+            queryGateway.query(
+                    query, CountCardSummariesResponse.class).whenComplete((r, exception) -> {
+                if (exception == null)
+                    statusLabel.setValue(Instant.ofEpochMilli(r.getLastEvent()).atOffset(instantOffset).toString());
+            });
 
-         }
+        }
 
     }
 }

--- a/src/main/java/io/axoniq/demo/giftcard/gui/GiftcardUI.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/GiftcardUI.java
@@ -174,7 +174,7 @@ class GiftcardUI extends UI {
         private final Label statusLabel;
         private final ZoneOffset instantOffset;
 
-        public StatusUpdater(Label statusLabel, ZoneOffset instantOffset) {
+        StatusUpdater(Label statusLabel, ZoneOffset instantOffset) {
             this.statusLabel = statusLabel;
             this.instantOffset = instantOffset;
         }

--- a/src/main/java/io/axoniq/demo/giftcard/gui/package-info.java
+++ b/src/main/java/io/axoniq/demo/giftcard/gui/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * GUI: Vaadin
+ */
+package io.axoniq.demo.giftcard.gui;

--- a/src/main/java/io/axoniq/demo/giftcard/query/CardSummaryProjection.java
+++ b/src/main/java/io/axoniq/demo/giftcard/query/CardSummaryProjection.java
@@ -18,7 +18,7 @@ import java.util.List;
 @XSlf4j
 @RequiredArgsConstructor
 @Profile("query")
-public class CardSummaryProjection {
+class CardSummaryProjection {
 
     private final EntityManager entityManager;
     private final QueryUpdateEmitter queryUpdateEmitter;

--- a/src/main/java/io/axoniq/demo/giftcard/query/CardSummaryProjection.java
+++ b/src/main/java/io/axoniq/demo/giftcard/query/CardSummaryProjection.java
@@ -24,7 +24,7 @@ class CardSummaryProjection {
     private final QueryUpdateEmitter queryUpdateEmitter;
 
     @EventHandler
-    public void on(IssuedEvt event) {
+    void on(IssuedEvt event) {
         log.trace("projecting {}", event);
         /*
          * Update our read model by inserting the new card. This is done so that upcoming regular
@@ -44,7 +44,7 @@ class CardSummaryProjection {
     }
 
     @EventHandler
-    public void on(RedeemedEvt event) {
+    void on(RedeemedEvt event) {
         log.trace("projecting {}", event);
         /*
          * Update our read model by updating the existing card. This is done so that upcoming regular
@@ -65,7 +65,7 @@ class CardSummaryProjection {
     }
 
     @QueryHandler
-    public List<CardSummary> handle(FetchCardSummariesQuery query) {
+    List<CardSummary> handle(FetchCardSummariesQuery query) {
         log.trace("handling {}", query);
         TypedQuery<CardSummary> jpaQuery = entityManager.createNamedQuery("CardSummary.fetch", CardSummary.class);
         jpaQuery.setParameter("idStartsWith", query.getFilter().getIdStartsWith());
@@ -75,7 +75,7 @@ class CardSummaryProjection {
     }
 
     @QueryHandler
-    public CountCardSummariesResponse handle(CountCardSummariesQuery query) {
+    CountCardSummariesResponse handle(CountCardSummariesQuery query) {
         log.trace("handling {}", query);
         TypedQuery<Long> jpaQuery = entityManager.createNamedQuery("CardSummary.count", Long.class);
         jpaQuery.setParameter("idStartsWith", query.getFilter().getIdStartsWith());

--- a/src/main/java/io/axoniq/demo/giftcard/query/package-info.java
+++ b/src/main/java/io/axoniq/demo/giftcard/query/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Query/Read model: Event handlers, Query handlers, Data projections
+ */
+package io.axoniq.demo.giftcard.query;

--- a/src/test/java/io/axoniq/demo/giftcard/ArchitectureTest.java
+++ b/src/test/java/io/axoniq/demo/giftcard/ArchitectureTest.java
@@ -8,11 +8,11 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import org.junit.runner.RunWith;
 
 @RunWith(ArchUnitRunner.class)
-@AnalyzeClasses(packages = "io.axoniq.demo.giftcard")
-public class GcAppTest {
+@AnalyzeClasses(packagesOf=ArchitectureTest.class)
+public class ArchitectureTest {
 
     /**
-     * Testing if the classes in "..command.. , ..query.. " packages are package protected.
+     * Testing if the classes in "..command.. , ..query.. ,..qui..  " packages are package protected.
      * <p>
      * This will work with Java only. Kotlin does not have package modifier.
      */

--- a/src/test/java/io/axoniq/demo/giftcard/ArchitectureTest.java
+++ b/src/test/java/io/axoniq/demo/giftcard/ArchitectureTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 public class ArchitectureTest {
 
     /**
-     * Testing if the classes in "..command.. , ..query.. ,..qui..  " packages are package protected.
+     * Testing if the classes in "..command.. , ..query.. ,..gui..  " packages are 'package private'.
      * <p>
      * This will work with Java only. Kotlin does not have package modifier.
      */

--- a/src/test/java/io/axoniq/demo/giftcard/GcAppTest.java
+++ b/src/test/java/io/axoniq/demo/giftcard/GcAppTest.java
@@ -1,0 +1,23 @@
+package io.axoniq.demo.giftcard;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import org.junit.runner.RunWith;
+
+@RunWith(ArchUnitRunner.class)
+@AnalyzeClasses(packages = "io.axoniq.demo.giftcard")
+public class GcAppTest {
+
+    /**
+     * Testing if the classes in "..command.. , ..query.. " packages are package protected.
+     * <p>
+     * This will work with Java only. Kotlin does not have package modifier.
+     */
+    @ArchTest
+    public static final ArchRule encapsulationJavaRule = ArchRuleDefinition.classes()
+            .that().resideInAnyPackage("..command..", "..query..", "..gui..")
+            .should().bePackagePrivate();
+}


### PR DESCRIPTION
ArchUnit test included to check if the classes in `command`, `query` and `gui` packages are package private. Only classes in `api` package should be public. This enables loose coupling and high cohesion