### PR TITLE
graceful shutdown test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,26 @@
             <artifactId>spring-boot-actuator</artifactId>
         </dependency>
 
+        <!-- restart test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.palantir.docker.compose</groupId>
+            <artifactId>docker-compose-junit-jupiter</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -224,4 +244,11 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>palantir-bintray</id>
+            <url>https://dl.bintray.com/palantir/releases</url>
+        </repository>
+    </repositories>
 </project>

--- a/src/test/java/io/axoniq/demo/giftcard/RestartTest.java
+++ b/src/test/java/io/axoniq/demo/giftcard/RestartTest.java
@@ -1,0 +1,140 @@
+package io.axoniq.demo.giftcard;
+
+import com.palantir.docker.compose.DockerComposeExtension;
+import com.palantir.docker.compose.configuration.ShutdownStrategy;
+import com.palantir.docker.compose.connection.Container;
+import com.palantir.docker.compose.connection.waiting.HealthChecks;
+import io.axoniq.demo.giftcard.api.CountCardSummariesQuery;
+import io.axoniq.demo.giftcard.api.CountCardSummariesResponse;
+import io.axoniq.demo.giftcard.api.IssuedEvt;
+import org.axonframework.eventhandling.gateway.EventGateway;
+import org.axonframework.queryhandling.QueryGateway;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Scenario:
+ * - given an axon-server with a huge amount of events to process
+ * - given a tracking-processor consumer
+ * - when the consumer is restarted often
+ * - then the number of overall events need to be consistent
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = GcApp.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ActiveProfiles(/*NONE*/)
+public class RestartTest {
+
+    @RegisterExtension
+    static final DockerComposeExtension AXON_SERVER = DockerComposeExtension
+            .builder()
+            .file("src/test/resources/docker-compose-restarttest.yml")
+            .waitingForService(
+                    "axonserver",
+                    HealthChecks.toRespond2xxOverHttp(
+                            8024,
+                            (port) -> port.inFormat("http://$HOST:$EXTERNAL_PORT")
+                    )
+            )
+            .shutdownStrategy(ShutdownStrategy.GRACEFUL)
+            .saveLogsTo("target/docker-compose-restarttest.logs")
+            .build();
+
+    static final Container GIFTCARD = AXON_SERVER.containers().container("giftcard");
+
+    static final long NUMBER_OF_EVENTS = 1L << 16; // 1<<32 = 4.294.967.296
+
+    static final Random R = new Random(1L);
+
+    @Autowired
+    EventGateway eventGateway;
+
+    @Autowired
+    QueryGateway queryGateway;
+
+    @Test
+    @Order(0)
+    public void resetTokenStore() throws IOException {
+        // wipe token-stores for dockerized giftcards and events-populator
+        Files.deleteIfExists(
+                Paths.get("./target/giftcard-volume/database.mv.db")
+        );
+
+        Files.deleteIfExists(
+                Paths.get("./target/giftcard-volume/database.trace.db")
+        );
+
+        Files.deleteIfExists(
+                Paths.get("./target/giftcard-volume/database.lock.db")
+        );
+    }
+
+
+    @Test
+    @Order(1)
+    public void eventsPopulate() {
+
+        // generate randomized events at sufficiently large scale
+        for (long i = 0L; i < NUMBER_OF_EVENTS; i++)
+            eventGateway.publish(
+                    new IssuedEvt(
+                            UUID.randomUUID().toString(),
+                            R.nextInt()
+                    )
+            );
+    }
+
+    @Disabled
+    @RepeatedTest(10)
+    @Order(2)
+    public void testRestartingConsumer() throws IOException, InterruptedException {
+        try {
+            GIFTCARD.start();
+
+            Thread.sleep(300L);
+        } finally {
+            GIFTCARD.kill();
+        }
+    }
+
+    @Test
+    @Order(3)
+    public void eventCompletenessCheck() throws ExecutionException, InterruptedException, IOException {
+        try {
+            // TODO disable further event handling here
+            GIFTCARD.start();
+
+            Thread.sleep(16000L);
+
+            CompletableFuture<CountCardSummariesResponse> query = queryGateway.query(
+                    new CountCardSummariesQuery(),
+                    CountCardSummariesResponse.class
+            );
+
+            int issued_giftcards_count = query.get().getCount();
+
+            assertEquals(
+                    NUMBER_OF_EVENTS,
+                    issued_giftcards_count,
+                    "There should not be skipped events."
+            );
+        } finally {
+            GIFTCARD.stop();
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,20 @@
+# The name of this app:
+spring.application.name=gc-test-${spring.profiles.active}
+
+# Debugging on
+## logging.level.io.axoniq.demo=DEBUG
+
+# We look for Axon Server locally, unless we find a PCF Binding for AxonServer
+axon.axonserver.servers=axonserver
+
+# The default is to have no Servlets
+spring.main.web-application-type=none
+
+# The default profiles are "all of them"
+spring.profiles.active=
+
+spring.datasource.url=jdbc:h2:./database;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE
+spring.jpa.hibernate.ddl-auto=update
+
+management.endpoint.health.show-details=always
+management.endpoints.web.exposure.include=*

--- a/src/test/resources/docker-compose-restarttest.yml
+++ b/src/test/resources/docker-compose-restarttest.yml
@@ -1,0 +1,23 @@
+version: '3'
+services:
+  axonserver:
+    image: axoniq/axonserver
+    hostname: axonserver
+    ports:
+      - '8024:8024'
+      - '8124:8124'
+      - '8224:8224'
+  giftcard:
+    image: openjdk:11
+    working_dir: /giftcard
+    volumes:
+      - '../../../target/giftcard-volume/:/giftcard'
+      - '../../../src/test/resources/application.properties:/giftcard/application.properties'
+      - '../../../target/giftcard-demo-4.3.5.jar:/giftcard/giftcard-demo.jar'
+    links:
+      - 'axonserver'
+    environment:
+      - 'AXON_AXONSERVER_SERVERS=axonserver'
+      - 'SPRING_PROFILES_ACTIVE=query'
+      - 'SPRING_APPLICATION_NAME=gc-docker-query'
+    entrypoint: ['java', '-jar', 'giftcard-demo.jar']


### PR DESCRIPTION
as part of chaos engineering, verify following assumption:
- tracking-processor and token-store don't skip any event over a series of restarts
- tracking-processor and token-store being killed during transaction should resume/retry upon restart

test setup:
- events-generator and test-runner
- axon-server (empty before each test-run)
- giftcard docker container being restarted,
having token-store and projection in a h2-database