### PR TITLE
Adding equals method to GiftCard for push update

### DIFF
--- a/src/main/java/io/axoniq/demo/giftcard/api/api.kt
+++ b/src/main/java/io/axoniq/demo/giftcard/api/api.kt
@@ -6,6 +6,7 @@ import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.NamedQueries
 import javax.persistence.NamedQuery
+import java.util.Objects
 
 data class IssueCmd(@TargetAggregateIdentifier val id: String, val amount: Int)
 data class IssuedEvt(val id: String, val amount: Int)
@@ -37,7 +38,7 @@ data class CardSummary(@Id var id: String, var initialValue: Int, var remainingV
     }
 	
 	 override fun hashCode(): Int {
-        return 31
+        return Objects.hash(id);
     }
 }
 

--- a/src/main/java/io/axoniq/demo/giftcard/api/api.kt
+++ b/src/main/java/io/axoniq/demo/giftcard/api/api.kt
@@ -22,6 +22,19 @@ data class CancelEvt(val id: String)
                 query = "SELECT COUNT(c) FROM CardSummary c WHERE c.id LIKE CONCAT(:idStartsWith, '%')"))
 data class CardSummary(@Id var id: String, var initialValue: Int, var remainingValue: Int) {
     constructor() : this("", 0, 0)
+	override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (javaClass != other?.javaClass) {
+            return false
+        }
+        other as CardSummary
+        if (id == other.id) {
+            return true
+        }
+        return false
+    }
 }
 
 data class CardSummaryFilter(val idStartsWith: String = "")

--- a/src/main/java/io/axoniq/demo/giftcard/api/api.kt
+++ b/src/main/java/io/axoniq/demo/giftcard/api/api.kt
@@ -35,6 +35,10 @@ data class CardSummary(@Id var id: String, var initialValue: Int, var remainingV
         }
         return false
     }
+	
+	 override fun hashCode(): Int {
+        return 31
+    }
 }
 
 data class CardSummaryFilter(val idStartsWith: String = "")


### PR DESCRIPTION
It is necessary to override the equals method with id comparison for Vaadin to push correctly the entity update to the client.
