### PR TITLE
Move to Spring Boot 3, making the required java version 17 instead of 11.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - java-version: 11
           - java-version: 17
       fail-fast: false
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To build the demo app, simply run the provided [Maven wrapper](https://www.baeld
 ./mvnw clean package
 ```
 
-Note that the Giftcard app expects JDK 11 to be used. 
+Note that the Giftcard app expects JDK 17 to be used. 
 
 Running the Giftcard app
 ------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.axoniq.demo</groupId>
     <artifactId>giftcard-demo</artifactId>
-    <version>4.6</version>
+    <version>4.7</version>
     <packaging>jar</packaging>
 
     <name>giftcard-demo</name>
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.9</version>
+        <version>3.0.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -23,15 +23,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <kotlin.version>1.8.10</kotlin.version>
 
-        <axon.version>4.7.1</axon.version>
+        <axon.version>4.7.2</axon.version>
 
         <dataprotection-config-api.version>1.0</dataprotection-config-api.version>
         <dataprotection-maven-plugin.version>1.0</dataprotection-maven-plugin.version>
 
-        <vaadin.version>8.14.3</vaadin.version>
+        <vaadin.version>24.0.0</vaadin.version>
         <lombok.version>1.18.26</lombok.version>
 
         <jaxb-runtime-version>3.0.0</jaxb-runtime-version>


### PR DESCRIPTION
Validated that the new version of Vaadin works without any additional code changes.